### PR TITLE
Partial fix for URL extraction 'terms not found' issue

### DIFF
--- a/src/xml_extract_all.py
+++ b/src/xml_extract_all.py
@@ -37,8 +37,9 @@ def extract_full_xml(xml_string):
             trailing_slash_variant = get_trailing_slash_variant(gt2t["text"])
             if trailing_slash_variant:
                 variants.append({"guessed_type": "uris", "text": trailing_slash_variant})
-    types_to_text.extend(variants)
-    return types_to_text
+    extended = list(types_to_text)
+    extended.extend(variants)
+    return types_to_text, extended
 
 
 def extract_data(element):


### PR DESCRIPTION
The previous implementation compares terms found with all terms parsed from the XML. This includes URIs and strings such as latitudes and longitudes. Found URI terms are also compared to variants of the base URI (so for example, http://vocab... is expanded to the https://vocab... variant, in addition to the no trailing backslash variants as well).

This partial fix does the comparison for terms not found against only URIs and specifically against the original versions and not the variants. This results in a smaller set of terms not found.